### PR TITLE
Property UI feat

### DIFF
--- a/frontend/backoffice/package-lock.json
+++ b/frontend/backoffice/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@mui/icons-material": "^6.4.7",
         "@tanstack/react-query": "^5.67.3",
+        "lucide-react": "^0.479.0",
         "material-icons": "^1.13.14",
         "next": "15.2.1",
         "ra-data-fakerest": "^5.6.3",
@@ -1733,7 +1734,6 @@
       "version": "19.0.10",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.10.tgz",
       "integrity": "sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -4798,6 +4798,15 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "0.479.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.479.0.tgz",
+      "integrity": "sha512-aBhNnveRhorBOK7uA4gDjgaf+YlHMdMhQ/3cupk6exM10hWlEU+2QtWYOfhXhjAsmdb6LeKR+NZnow4UxRRiTQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/material-icons": {
       "version": "1.13.14",
       "resolved": "https://registry.npmjs.org/material-icons/-/material-icons-1.13.14.tgz",
@@ -5502,6 +5511,13 @@
         "react-router": "^6.28.1 || ^7.1.1",
         "react-router-dom": "^6.28.1 || ^7.1.1"
       }
+    },
+    "node_modules/react-admin/node_modules/react-is": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.0.0.tgz",
+      "integrity": "sha512-H91OHcwjZsbq3ClIDHMzBShc1rotbfACdWENsmEf0IFvZ3FgGPtdHMcsv45bQ1hAbgdfiA8SnxTKfDS+x/8m2g==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-dom": {
       "version": "19.0.0",

--- a/frontend/backoffice/package.json
+++ b/frontend/backoffice/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@mui/icons-material": "^6.4.7",
     "@tanstack/react-query": "^5.67.3",
+    "lucide-react": "^0.479.0",
     "material-icons": "^1.13.14",
     "next": "15.2.1",
     "ra-data-fakerest": "^5.6.3",

--- a/frontend/backoffice/src/AdminApp.tsx
+++ b/frontend/backoffice/src/AdminApp.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import fakeDataProvider from "ra-data-fakerest";
+import { deepmerge } from '@mui/utils';
 import { getResources } from "./resources";
-import { Admin, Resource } from "react-admin";
+import { Admin, radiantDarkTheme, Resource } from "react-admin";
 import authProvider from "./state/providers/authProvider";
 import { I_User } from "./types/authTypes";
 
@@ -20,11 +21,97 @@ const dataProvider = fakeDataProvider({
   properties: [
     {
       id: 1,
-      firstName: "Justine",
-      lastName: "Okumu",
-      username: "okumujustine",
+      name: "Luxurous house",
+      banner: 'https://images.unsplash.com/photo-1613490493576-7fde63acd811?auto=format&fit=crop&q=80&w=1600',
+      location: "Fairfied",
+      price: "$ 45,000",
+      images: [
+        "https://images.unsplash.com/photo-1518756131217-31eb79b20e8f",
+        "https://images.unsplash.com/photo-1518756131217-31eb79b20e8f",
+        "https://images.unsplash.com/photo-1518756131217-31eb79b20e8f",
+        "https://images.unsplash.com/photo-1518756131217-31eb79b20e8f",
+        "https://images.unsplash.com/photo-1518756131217-31eb79b20e8f"
+      ],
+      propertyOwner: {
+        id: 1,
+        firstName: "Okello",
+        lastName: "John",
+        username: "johny",
+      },
+      isBooked: true,
+      amenities: ['Pool', 'Beach Access', 'Smart Home'],
+       description: "Description here"
     },
-    { id: 2, firstName: "Sunday", lastName: "Nyeko", username: "sundayn" },
+    {
+      id: 2,
+      name: "Luxurous house 2",
+      banner: 'https://images.unsplash.com/photo-1560448204-e02f11c3d0e2?auto=format&fit=crop&q=80&w=1600',
+      images: [
+        "https://images.unsplash.com/photo-1518756131217-31eb79b20e8f",
+        "https://images.unsplash.com/photo-1518756131217-31eb79b20e8f",
+        "https://images.unsplash.com/photo-1518756131217-31eb79b20e8f",
+        "https://images.unsplash.com/photo-1518756131217-31eb79b20e8f",
+        "https://images.unsplash.com/photo-1518756131217-31eb79b20e8f"
+      ],
+      location: "Fairfied",
+      price: "$ 45,000",
+      propertyOwner: {
+        id: 2,
+        firstName: "Sunday",
+        lastName: "Nyeko",
+        username: "sundayson",
+      },
+      isBooked: false,
+      amenities: ['Pool', 'Beach Access', 'Smart Home'],
+       description: "Description here"
+    },
+    {
+      id: 3,
+      name: "Seaside Villa",
+      banner: 'https://images.unsplash.com/photo-1522708323590-d24dbb6b0267?auto=format&fit=crop&q=80&w=1600',
+      images: [
+        "https://images.unsplash.com/photo-1518756131217-31eb79b20e8f",
+        "https://images.unsplash.com/photo-1518756131217-31eb79b20e8f",
+        "https://images.unsplash.com/photo-1518756131217-31eb79b20e8f",
+        "https://images.unsplash.com/photo-1518756131217-31eb79b20e8f",
+        "https://images.unsplash.com/photo-1518756131217-31eb79b20e8f"
+      ],
+      location: "Seaside",
+      price: "$ 65,000",
+      propertyOwner: {
+        id: 3,
+        firstName: "Grace",
+        lastName: "Ocen",
+        username: "graceocen",
+      },
+      isBooked: false,
+      amenities: ['Infinity Pool', 'Private Beach', 'Spa'],
+      description: "Description here"
+    },
+    {
+      id: 4,
+      name: "Mountain Retreat",
+      banner: 'https://images.unsplash.com/photo-1512917774080-9991f1c4c750?auto=format&fit=crop&q=80&w=1600',
+      images: [
+        "https://images.unsplash.com/photo-1518756131217-31eb79b20e8f",
+        "https://images.unsplash.com/photo-1518756131217-31eb79b20e8f",
+        "https://images.unsplash.com/photo-1518756131217-31eb79b20e8f",
+        "https://images.unsplash.com/photo-1518756131217-31eb79b20e8f",
+        "https://images.unsplash.com/photo-1518756131217-31eb79b20e8f"
+      ],
+      location: "Mountain Range",
+      price: "$ 55,000",
+      propertyOwner: {
+        id: 4,
+        firstName: "Peter",
+        lastName: "Otto",
+        username: "peterotto",
+      },
+      isBooked: false,
+      amenities: ['Panoramic Views', 'Hiking Trails', 'Fireplace'],
+       description: "Description here"
+    }
+    
   ],
 
   bookings: [
@@ -50,8 +137,19 @@ export default function AdminApp() {
     avatar: "https://example.com/avatar.jpg",
   };
 
+  const theme = deepmerge(radiantDarkTheme, {
+    sidebar: {
+        width: 220, // The default value is 240
+        closedWidth: 70, // The default value is 55
+    },
+});
+
   return (
-    <Admin dataProvider={dataProvider} authProvider={authProvider}>
+    <Admin
+      darkTheme={theme}
+      dataProvider={dataProvider}
+      authProvider={authProvider}
+    >
       {(currentUserRole) => {
         return getResources(currentUserRole).map((resource) => {
           return <Resource key={resource.name} {...resource} />;

--- a/frontend/backoffice/src/components/common/ImageList.tsx
+++ b/frontend/backoffice/src/components/common/ImageList.tsx
@@ -1,0 +1,108 @@
+import * as React from "react";
+import { Avatar, Box, Paper, Typography } from "@mui/material";
+import {
+  Link,
+  RecordContextProvider,
+  useCreatePath,
+  useListContext,
+  useRecordContext,
+} from "react-admin";
+import { T_Property } from "@/types/property";
+
+const times = (nbChildren: number, fn: (key: number) => any) =>
+  Array.from({ length: nbChildren }, (_, key) => fn(key));
+
+const LoadingGridList = () => (
+  <Box display="flex" flexWrap="wrap" width={1008} gap={1}>
+    {times(15, (key) => (
+      <Paper
+        sx={{
+          height: 200,
+          width: 194,
+          display: "flex",
+          flexDirection: "column",
+          backgroundColor: "grey[200]",
+        }}
+        key={key}
+      />
+    ))}
+  </Box>
+);
+
+const PropertyCard = (props: { record?: T_Property }) => {
+  const record = useRecordContext<T_Property>(props);
+  const [elevation, setElevation] = React.useState(1);
+  const createPath = useCreatePath();
+
+  if (!record) return null;
+
+  return (
+    <Link
+      to={createPath({
+        resource: "properties",
+        id: record.id,
+        type: "show",
+      })}
+      underline="none"
+      onMouseEnter={() => setElevation(3)}
+      onMouseLeave={() => setElevation(1)}
+    >
+      <Paper
+        sx={{
+          height: 200,
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          padding: "1em",
+        }}
+        elevation={elevation}
+      >
+        <Box display="flex" flexDirection="column" alignItems="center">
+          <Avatar
+            src={record.banner}
+            alt={record.name}
+            sx={{
+              "& img": { objectFit: "contain" },
+              "&.MuiAvatar-colorDefault": {
+                color: "primary.contrastText",
+              },
+            }}
+          >
+            {record.name.charAt(0)}
+          </Avatar>
+          <Box textAlign="center" marginTop={1}>
+            <Typography variant="subtitle2">{record.name}</Typography>
+          </Box>
+        </Box>
+      </Paper>
+    </Link>
+  );
+};
+
+const LoadedGridList = () => {
+  const { data, error, isPending } = useListContext<any>();
+
+  if (isPending || error) return null;
+
+  return (
+    <Box
+      width="100%"
+      gap={1}
+      display="grid"
+      gridTemplateColumns="repeat(auto-fill, minmax(180px, 1fr))"
+    >
+      {data.map((record) => (
+        <RecordContextProvider key={record.id} value={record}>
+          <PropertyCard />
+        </RecordContextProvider>
+      ))}
+
+      {data.length === 0 && <Typography p={2}>No properties found</Typography>}
+    </Box>
+  );
+};
+
+export const ImageList = () => {
+  const { isPending } = useListContext();
+  return isPending ? <LoadingGridList /> : <LoadedGridList />;
+};

--- a/frontend/backoffice/src/components/properties/Aside.tsx
+++ b/frontend/backoffice/src/components/properties/Aside.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { Card, CardContent } from "@mui/material";
+import { FilterList, FilterListItem } from "react-admin";
+import AccessTimeIcon from "@mui/icons-material/AccessTime";
+
+export default function Aside() {
+  return (
+    <Card
+      sx={{
+        display: {
+          xs: "none",
+          md: "block",
+        },
+        order: -1,
+        flex: "0 0 15em",
+        mr: 2,
+        alignSelf: "flex-start",
+      }}
+    >
+      <CardContent sx={{ pt: 1 }}>
+        <FilterList label="Filter" icon={<AccessTimeIcon />}>
+          <FilterListItem
+            label="Open"
+            value={{
+              status: 'open',
+            }}
+          />
+          <FilterListItem
+            label="Booked"
+            value={{
+               status: 'booked',
+            }}
+          />
+        </FilterList>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/backoffice/src/components/properties/ListComponent.tsx
+++ b/frontend/backoffice/src/components/properties/ListComponent.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { Card, CardMedia } from "@mui/material";
+import { useRecordContext } from "react-admin";
+import { T_Property } from "@/types/property";
+
+export const ListComponent = () => {
+  const record = useRecordContext<T_Property>();
+  if (!record) return null;
+  return (
+    <Card sx={{ display: "inline-block" }}>
+      <CardMedia
+        component="img"
+        image={record.banner}
+        alt=""
+        sx={{ maxWidth: "42em", maxHeight: "15em" }}
+      />
+    </Card>
+  );
+};

--- a/frontend/backoffice/src/components/properties/PropertyCard.tsx
+++ b/frontend/backoffice/src/components/properties/PropertyCard.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import {
+  Card,
+  CardContent,
+  CardMedia,
+  Chip,
+  Typography,
+  Box,
+} from "@mui/material";
+import { T_Property } from "@/types/property";
+
+interface PropertyCardProps {
+  property: T_Property;
+}
+
+export const PropertyCard: React.FC<PropertyCardProps> = ({ property }) => {
+  return (
+    <Card
+      sx={{
+        height: "200px",
+        width: "100%",
+        position: "relative",
+        cursor: "pointer",
+        transition: "transform 0.2s ease-in-out",
+        "&:hover": {
+          transform: "scale(1.02)",
+        },
+      }}
+    >
+      <CardMedia
+        component="img"
+        height="200"
+        image={property.banner}
+        alt={property.name}
+        sx={{
+          objectFit: "cover",
+          height: "100%",
+        }}
+      />
+      <Box
+        sx={{
+          position: "absolute",
+          top: 0,
+          right: 0,
+          p: 1,
+        }}
+      >
+        <Chip
+          label={property.isBooked ? "Booked" : "Available"}
+          color={property.isBooked ? "error" : "success"}
+          size="small"
+          sx={{
+            backgroundColor: property.isBooked
+              ? "rgba(211, 47, 47, 0.9)"
+              : "rgba(46, 125, 50, 0.9)",
+            color: "white",
+          }}
+        />
+      </Box>
+      <CardContent
+        sx={{
+          position: 'absolute',
+          bottom: 0,
+          width: '100%',
+          background: 'linear-gradient(to top, rgba(0,0,0,0.9), rgba(0,0,0,0.7))',
+          p: 1,
+          '&:last-child': { pb: 1 },
+        }}
+      >
+        <Typography
+          variant="subtitle2"
+          component="h3"
+          sx={{
+            color: 'white',
+            fontWeight: 600,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            textShadow: '0px 1px 2px rgba(0,0,0,0.5)',
+            fontSize: '0.9rem',
+            letterSpacing: '0.25px',
+          }}
+        >
+          {property.name}
+        </Typography>
+      </CardContent>
+    </Card>
+  );
+};

--- a/frontend/backoffice/src/components/properties/PropertyCard.tsx
+++ b/frontend/backoffice/src/components/properties/PropertyCard.tsx
@@ -8,14 +8,18 @@ import {
   Box,
 } from "@mui/material";
 import { T_Property } from "@/types/property";
+import { useRedirect } from "react-admin";
 
 interface PropertyCardProps {
   property: T_Property;
 }
 
 export const PropertyCard: React.FC<PropertyCardProps> = ({ property }) => {
+  const redirect = useRedirect();
+
   return (
     <Card
+      onClick={() => redirect("show", "properties", property.id)}
       sx={{
         height: "200px",
         width: "100%",
@@ -59,26 +63,27 @@ export const PropertyCard: React.FC<PropertyCardProps> = ({ property }) => {
       </Box>
       <CardContent
         sx={{
-          position: 'absolute',
+          position: "absolute",
           bottom: 0,
-          width: '100%',
-          background: 'linear-gradient(to top, rgba(0,0,0,0.9), rgba(0,0,0,0.7))',
+          width: "100%",
+          background:
+            "linear-gradient(to top, rgba(0,0,0,0.9), rgba(0,0,0,0.7))",
           p: 1,
-          '&:last-child': { pb: 1 },
+          "&:last-child": { pb: 1 },
         }}
       >
         <Typography
           variant="subtitle2"
           component="h3"
           sx={{
-            color: 'white',
+            color: "white",
             fontWeight: 600,
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-            textShadow: '0px 1px 2px rgba(0,0,0,0.5)',
-            fontSize: '0.9rem',
-            letterSpacing: '0.25px',
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+            textShadow: "0px 1px 2px rgba(0,0,0,0.5)",
+            fontSize: "0.9rem",
+            letterSpacing: "0.25px",
           }}
         >
           {property.name}

--- a/frontend/backoffice/src/components/property-owners/OwnerAvatar.tsx
+++ b/frontend/backoffice/src/components/property-owners/OwnerAvatar.tsx
@@ -1,0 +1,27 @@
+import { useRecordContext } from "react-admin";
+import { Avatar } from "@mui/material";
+
+export const PropertyOwnerAvatar = ({
+  size = "normal",
+}: {
+  size?: "small" | "normal" | "large";
+}) => {
+  const record = useRecordContext();
+  if (!record) return null;
+
+  const sizeStyles = {
+    small: { width: 24, height: 24 },
+    normal: { width: 48, height: 48 },
+    large: { width: 80, height: 80 },
+  };
+
+  return (
+    <Avatar
+      src={record.avatar}
+      sx={{
+        borderRadius: "50%",
+        ...sizeStyles[size],
+      }}
+    />
+  );
+};

--- a/frontend/backoffice/src/properties/create.tsx
+++ b/frontend/backoffice/src/properties/create.tsx
@@ -1,0 +1,381 @@
+import React, { useState } from "react";
+import { useRedirect, useNotify, useDataProvider, Button } from "react-admin";
+import {
+  Card,
+  CardContent,
+  Typography,
+  TextField,
+  Box,
+  Grid,
+  Stepper,
+  Step,
+  StepLabel,
+  IconButton,
+  Dialog,
+  DialogContent,
+  Chip,
+  InputAdornment,
+} from "@mui/material";
+import { ArrowLeft, Plus, X } from "lucide-react";
+import { T_PropertyCreate } from "@/types/property";
+
+const steps = ["Property Details", "Upload Images", "Review & Submit"];
+
+const CreateProperty = () => {
+  const redirect = useRedirect();
+  const notify = useNotify();
+  const dataProvider = useDataProvider();
+  const [activeStep, setActiveStep] = useState(0);
+  const [zoomImage, setZoomImage] = useState<string | null>(null);
+  const [newAmenity, setNewAmenity] = useState("");
+  const [formData, setFormData] = useState<T_PropertyCreate>({
+    name: "",
+    description: "",
+    price: "",
+    location: "",
+    banner: "",
+    images: [],
+    amenities: [],
+  });
+
+  const handleInputChange = (e: any) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const isStepValid = () => {
+    if (activeStep === 0) {
+      return (
+        formData.name && formData.location && formData.price && formData.description && formData.amenities.length > 0
+      );
+    }
+    if (activeStep === 1) {
+      return formData.images.length > 1;
+    }
+    return true;
+  };
+
+  const handleNext = () => {
+    if (isStepValid()) {
+      setActiveStep((prev) => prev + 1);
+    } else {
+      notify("Please fill all required fields before proceeding", {
+        type: "warning",
+      });
+    }
+  };
+
+  const handleBack = () => setActiveStep((prev) => prev - 1);
+
+  const handleSubmit = async (e: any) => {
+    e.preventDefault();
+    try {
+      await dataProvider.create("properties", { data: formData });
+      notify("Property created successfully", { type: "success" });
+      redirect("/properties");
+    } catch (error) {
+      notify("Error creating property", { type: "error" });
+    }
+  };
+
+  const handleAddAmenity = () => {
+    if (newAmenity.trim() && !formData.amenities.includes(newAmenity.trim())) {
+      setFormData((prev) => ({
+        ...prev,
+        amenities: [...prev.amenities, newAmenity.trim()],
+      }));
+      setNewAmenity("");
+    }
+  };
+
+  const handleRemoveAmenity = (amenityToRemove: string) => {
+    setFormData((prev) => ({
+      ...prev,
+      amenities: prev.amenities.filter(
+        (amenity) => amenity !== amenityToRemove
+      ),
+    }));
+  };
+
+  return (
+    <div style={{ width: "1200px", margin: 20 }}>
+      <Stepper activeStep={activeStep} sx={{ mb: 3 }}>
+        {steps.map((label) => (
+          <Step key={label}>
+            <StepLabel>{label}</StepLabel>
+          </Step>
+        ))}
+      </Stepper>
+
+      <Card>
+        <CardContent>
+          {activeStep === 0 && (
+            <Grid container spacing={3}>
+              <Grid item xs={12}>
+                <TextField
+                  fullWidth
+                  label="Property Title"
+                  name="name"
+                  value={formData.name}
+                  onChange={handleInputChange}
+                  required
+                />
+              </Grid>
+              <Grid item xs={12} sm={6}>
+                <TextField
+                  fullWidth
+                  label="Location"
+                  name="location"
+                  value={formData.location}
+                  onChange={handleInputChange}
+                  required
+                />
+              </Grid>
+              <Grid item xs={12} sm={6}>
+                <TextField
+                  fullWidth
+                  label="Price"
+                  name="price"
+                  type="number"
+                  value={formData.price}
+                  onChange={handleInputChange}
+                  InputProps={{
+                    startAdornment: (
+                      <InputAdornment position="start">$</InputAdornment>
+                    ),
+                  }}
+                  required
+                />
+              </Grid>
+              <Grid item xs={12}>
+                <TextField
+                  fullWidth
+                  label="Description"
+                  name="description"
+                  value={formData.description}
+                  onChange={handleInputChange}
+                  multiline
+                  rows={4}
+                  required
+                />
+              </Grid>
+              <Grid item xs={12}>
+                <Typography variant="subtitle1" sx={{ mb: 1 }}>
+                  Amenities
+                </Typography>
+                <Box sx={{ display: "flex", gap: 1, mb: 2 }}>
+                  <TextField
+                    size="small"
+                    value={newAmenity}
+                    onChange={(e) => setNewAmenity(e.target.value)}
+                    placeholder="Add amenity"
+                    onKeyUp={(e) => {
+                      if (e.key === "Enter") {
+                        e.preventDefault();
+                        handleAddAmenity();
+                      }
+                    }}
+                  />
+                  <Button
+                    variant="contained"
+                    onClick={handleAddAmenity}
+                    startIcon={<Plus size={20} />}
+                  >
+                    <span>Add</span>
+                  </Button>
+                </Box>
+                <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+                  {formData.amenities.map((amenity, index) => (
+                    <Chip
+                      key={index}
+                      label={amenity}
+                      onDelete={() => handleRemoveAmenity(amenity)}
+                      deleteIcon={<X size={16} />}
+                    />
+                  ))}
+                </Box>
+              </Grid>
+              <Box
+                sx={{
+                  display: "flex",
+                  gap: 2,
+                  justifyContent: "flex-end",
+                  mt: 4,
+                  ml: 3,
+                }}
+              >
+                <Button onClick={handleNext} disabled={!isStepValid()}>
+                  <span>Next</span>
+                </Button>
+              </Box>
+            </Grid>
+          )}
+
+          {activeStep === 1 && (
+            <Grid container spacing={3}>
+              <Grid item xs={12}>
+                <Typography variant="h6">Upload House Images</Typography>
+                <Box
+                  sx={{ display: "flex", alignItems: "center", gap: 2, mt: 2 }}
+                >
+                  <label htmlFor="upload-images">
+                    <Button component="span">
+                      <div style={{ display: "flex", alignItems: "center" }}>
+                        <Plus size={18} />
+                        <span>Upload Images</span>
+                      </div>
+                    </Button>
+                  </label>
+                  <input
+                    id="upload-images"
+                    type="file"
+                    multiple
+                    accept="image/*"
+                    hidden
+                    onChange={(e) => {
+                      const files = Array.from(e.target.files || []);
+                      setFormData((prev) => ({
+                        ...prev,
+                        images: [...prev.images, ...files],
+                      }));
+                    }}
+                  />
+                </Box>
+              </Grid>
+
+              <Grid item xs={12}>
+                <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap", mt: 2 }}>
+                  {formData.images.map((file, index) => {
+                    const imgUrl = URL.createObjectURL(file);
+                    return (
+                      <Box
+                        key={index}
+                        sx={{
+                          position: "relative",
+                          width: "120px",
+                          height: "120px",
+                          borderRadius: "8px",
+                          overflow: "hidden",
+                          border: "2px solid #ddd",
+                          display: "flex",
+                          alignItems: "center",
+                          justifyContent: "center",
+                          cursor: "pointer",
+                        }}
+                        onClick={() => setZoomImage(imgUrl)}
+                      >
+                        <img
+                          src={imgUrl}
+                          alt={`Preview ${index + 1}`}
+                          style={{
+                            maxWidth: "100%",
+                            maxHeight: "100%",
+                            objectFit: "cover",
+                          }}
+                        />
+                        <IconButton
+                          sx={{
+                            position: "absolute",
+                            top: -8,
+                            right: -8,
+                            background: "#f00",
+                            color: "#fff",
+                          }}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setFormData((prev) => ({
+                              ...prev,
+                              images: prev.images.filter((_, i) => i !== index),
+                            }));
+                          }}
+                        >
+                          <X size={14} />
+                        </IconButton>
+                      </Box>
+                    );
+                  })}
+                </Box>
+              </Grid>
+              <Grid item xs={12}>
+                <Button onClick={handleBack} sx={{ mr: 3 }}>
+                  <span>Back</span>
+                </Button>
+
+                <Button onClick={handleNext} disabled={!isStepValid()}>
+                  <span>Next</span>
+                </Button>
+              </Grid>
+            </Grid>
+          )}
+
+          {activeStep === 2 && (
+            <Grid container spacing={3}>
+              <Grid item xs={12}>
+                <Typography variant="h6">Review & Submit</Typography>
+                <Typography>
+                  <strong>Title:</strong> {formData.name}
+                </Typography>
+                <Typography>
+                  <strong>Description:</strong> {formData.description}
+                </Typography>
+                <Typography>
+                  <strong>Price:</strong> {formData.price}
+                </Typography>
+                <Typography>
+                  <strong>Location:</strong> {formData.location}
+                </Typography>
+                <Typography>
+                  <strong>Amenities:</strong> {formData.amenities.join(", ")}
+                </Typography>
+                <Typography>
+                  <strong>Uploaded Images:</strong>
+                </Typography>
+                <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap", mt: 2 }}>
+                  {formData.images.map((file, index) => {
+                    const imgUrl = URL.createObjectURL(file);
+                    return (
+                      <img
+                        key={index}
+                        src={imgUrl}
+                        alt={`Review ${index + 1}`}
+                        style={{
+                          width: "100px",
+                          height: "100px",
+                          objectFit: "cover",
+                          borderRadius: "8px",
+                        }}
+                      />
+                    );
+                  })}
+                </Box>
+              </Grid>
+              <Box
+                sx={{
+                  display: "flex",
+                  gap: 2,
+                  justifyContent: "space-between",
+                  mt: 4,
+                  ml: 3,
+                }}
+              >
+                <Button onClick={handleBack}>
+                  <span>Back</span>
+                </Button>
+                <Button
+                  type="submit"
+                  variant="contained"
+                  color="primary"
+                  onClick={handleSubmit}
+                >
+                  <span>Submit</span>
+                </Button>
+              </Box>
+            </Grid>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default CreateProperty;

--- a/frontend/backoffice/src/properties/index.ts
+++ b/frontend/backoffice/src/properties/index.ts
@@ -2,11 +2,13 @@ import { ListGuesser, ResourceProps } from "react-admin";
 import { House } from "@mui/icons-material";
 import ListProperties from "./list";
 import CreateProperty from "./create";
+import PropertyShow from "./show";
 
 export const properties: ResourceProps = {
     name: "properties",
     options: { label: "Properties" },
     icon: House,
     list: ListProperties,
-    create: CreateProperty
+    create: CreateProperty,
+    show: PropertyShow
   };

--- a/frontend/backoffice/src/properties/index.ts
+++ b/frontend/backoffice/src/properties/index.ts
@@ -1,9 +1,12 @@
 import { ListGuesser, ResourceProps } from "react-admin";
 import { House } from "@mui/icons-material";
+import ListProperties from "./list";
+import CreateProperty from "./create";
 
 export const properties: ResourceProps = {
     name: "properties",
     options: { label: "Properties" },
     icon: House,
-    list: ListGuesser
+    list: ListProperties,
+    create: CreateProperty
   };

--- a/frontend/backoffice/src/properties/list.tsx
+++ b/frontend/backoffice/src/properties/list.tsx
@@ -1,0 +1,34 @@
+import { List, ListProps, useListContext } from "react-admin";
+import { Container } from "@mui/material";
+import { T_Property } from "@/types/property";
+import { PropertyCard } from "@/components/properties/PropertyCard";
+
+const ListProperties = (props: ListProps) => {
+  return (
+    <List {...props}>
+      <CustomPropertyList />
+    </List>
+  );
+};
+
+const CustomPropertyList = () => {
+  const { data } = useListContext<T_Property>();
+
+  return (
+    <div
+      style={{
+        padding: "16px",
+        paddingBottom: "16px",
+        display: "grid",
+        gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))",
+        gap: "16px",
+      }}
+    >
+      {data?.map((property) => (
+        <PropertyCard key={property.id} property={property} />
+      ))}
+    </div>
+  );
+};
+
+export default ListProperties;

--- a/frontend/backoffice/src/properties/show.tsx
+++ b/frontend/backoffice/src/properties/show.tsx
@@ -1,0 +1,104 @@
+import {
+  Show,
+  ShowProps,
+  useShowContext,
+} from "react-admin";
+import { Container, Typography, Box, Grid, Chip } from "@mui/material";
+
+const PropertyShow = (props: ShowProps) => {
+  return (
+    <Show {...props}>
+      <ShowView />
+    </Show>
+  );
+};
+
+export const ShowView = () => {
+  const { record } = useShowContext();
+
+  if (!record) return null;
+
+  return (
+    <Container sx={{ my: 2 }}>
+      {/* Banner Image */}
+      <Box
+        sx={{
+          width: "100%",
+          height: 300,
+          backgroundImage: `url(${record.banner || "/placeholder.jpg"})`,
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+          borderRadius: 2,
+        }}
+      />
+
+      {/* Property Details */}
+      <Grid container spacing={4} sx={{ mt: 3 }}>
+        {/* Left Column: Property Info */}
+        <Grid item xs={12} md={6}>
+          <Typography variant="h4" fontWeight="bold">
+            {record.name}
+          </Typography>
+
+          {/* Booking Status */}
+          <Chip
+            label={record.isBooked ? "Booked" : "Available"}
+            color={record.isBooked ? "error" : "success"}
+            sx={{ fontSize: 16, fontWeight: "bold", mt: 1 }}
+          />
+
+          <Typography variant="body1" color="text.secondary" sx={{ mt: 1 }}>
+            {record.description}
+          </Typography>
+
+          <Typography variant="h6" sx={{ mt: 2 }}>
+            Price: <strong>${record.price}</strong>
+          </Typography>
+
+          <Typography variant="h6">
+            Location: <strong>{record.location}</strong>
+          </Typography>
+
+          <Typography variant="h6">
+            Amenities: {record.amenities?.join(", ") || "N/A"}
+          </Typography>
+        </Grid>
+
+        {/* Right Column: Additional Images */}
+        <Grid item xs={12} md={6}>
+          <Typography variant="h6" fontWeight="bold">
+            Gallery
+          </Typography>
+          <Box
+            sx={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fill, minmax(150px, 1fr))",
+              gap: 2,
+              mt: 1,
+            }}
+          >
+            {record.images?.length > 0 ? (
+              record.images.map((img: string, index: number) => (
+                <Box
+                  key={index}
+                  sx={{
+                    width: "100%",
+                    height: 120,
+                    backgroundImage: `url(${img})`,
+                    backgroundSize: "cover",
+                    backgroundPosition: "center",
+                    borderRadius: 2,
+                  }}
+                />
+              ))
+            ) : (
+              <Typography>No images available</Typography>
+            )}
+          </Box>
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default PropertyShow;

--- a/frontend/backoffice/src/property-owners/create.tsx
+++ b/frontend/backoffice/src/property-owners/create.tsx
@@ -1,14 +1,28 @@
-import { Create, required, SimpleForm, TextInput } from "react-admin";
+import {
+  Create,
+  ImageField,
+  ImageInput,
+  required,
+  SimpleForm,
+  TextInput,
+} from "react-admin";
 
 export const CreatePropertyOwner: React.FC = (props) => {
-    return (
-      <Create { ...props }>
-        <SimpleForm>
-          <TextInput source="username" validate={[required()]} />
-          <TextInput source="firstName" validate={[required()]} />
-          <TextInput source="lastName" validate={[required()]} />
-          <TextInput type="password" source="password" validate={[required()]} />
-        </SimpleForm>
-      </Create>
-    );
-  };
+  return (
+    <Create {...props}>
+      <SimpleForm>
+        <ImageInput
+          source="avatar"
+          label="Avatar"
+          accept={{ "image/*": [".png", ".jpg"] }}
+        >
+          <ImageField source="src" title="title" />
+        </ImageInput>
+        <TextInput source="username" validate={[required()]} />
+        <TextInput source="firstName" validate={[required()]} />
+        <TextInput source="lastName" validate={[required()]} />
+        <TextInput type="password" source="password" validate={[required()]} />
+      </SimpleForm>
+    </Create>
+  );
+};

--- a/frontend/backoffice/src/property-owners/edit.tsx
+++ b/frontend/backoffice/src/property-owners/edit.tsx
@@ -1,9 +1,23 @@
-import { Edit, required, SimpleForm, TextInput } from "react-admin";
+import {
+  Edit,
+  ImageField,
+  ImageInput,
+  required,
+  SimpleForm,
+  TextInput,
+} from "react-admin";
 
 export const EditPropertyOwner: React.FC = (props) => {
   return (
     <Edit {...props}>
       <SimpleForm>
+        <ImageInput
+          source="avatar"
+          label="Avatar"
+          accept={{ "image/*": [".png", ".jpg"] }}
+        >
+          <ImageField source="src" title="title" />
+        </ImageInput>
         <TextInput source="username" readOnly />
         <TextInput source="firstName" validate={[required()]} />
         <TextInput source="lastName" validate={[required()]} />

--- a/frontend/backoffice/src/property-owners/index.ts
+++ b/frontend/backoffice/src/property-owners/index.ts
@@ -1,8 +1,9 @@
-import { ListGuesser, ResourceProps, ShowGuesser } from "react-admin";
+import { ResourceProps } from "react-admin";
 import { Person2 } from "@mui/icons-material";
 import { CreatePropertyOwner } from "./create";
 import { EditPropertyOwner } from "./edit";
 import { ListPropertyOwners } from "./list";
+import { ShowPropertyOwner } from "./show";
 
 export const productOwners: ResourceProps = {
     name: "propertyOwners",
@@ -11,5 +12,5 @@ export const productOwners: ResourceProps = {
     list: ListPropertyOwners,
     edit: EditPropertyOwner,
     create: CreatePropertyOwner,
-    show: ShowGuesser,
+    show: ShowPropertyOwner,
   };

--- a/frontend/backoffice/src/property-owners/list.tsx
+++ b/frontend/backoffice/src/property-owners/list.tsx
@@ -1,12 +1,14 @@
+import { PropertyOwnerAvatar } from "@/components/property-owners/OwnerAvatar";
 import React from "react";
 import { Datagrid, List, TextField } from "react-admin";
 
 export const ListPropertyOwners: React.FC = () => (
   <List>
     <Datagrid>
-        <TextField source="username" />
+        <PropertyOwnerAvatar size="normal" />
         <TextField source="firstName" />
         <TextField source="lastName" />
+        <TextField source="username" />
     </Datagrid>
   </List>
 );

--- a/frontend/backoffice/src/property-owners/show.tsx
+++ b/frontend/backoffice/src/property-owners/show.tsx
@@ -1,0 +1,13 @@
+import { PropertyOwnerAvatar } from "@/components/property-owners/OwnerAvatar";
+import { Show, ShowProps, SimpleShowLayout, TextField } from "react-admin";
+
+export const ShowPropertyOwner = (props: ShowProps) => (
+  <Show {...props} >
+    <SimpleShowLayout>
+      <PropertyOwnerAvatar size="large" />
+      <TextField sx={{ fontSize: "18px"}} source="username" />
+      <TextField sx={{ fontSize: "18px"}} source="firstName" />
+      <TextField sx={{ fontSize: "18px"}} source="firstName" />
+    </SimpleShowLayout>
+  </Show>
+);

--- a/frontend/backoffice/src/types/property.ts
+++ b/frontend/backoffice/src/types/property.ts
@@ -1,0 +1,29 @@
+export type I_PropertyOwner = {
+    id: number,
+    firstName: string,
+    lastName: string,
+    username: string,
+}
+
+export type T_Property = {
+    id: number,
+    name: string,
+    banner: string,
+    images: string[],
+    propertyOwner: I_PropertyOwner,
+    location: string,
+    price: string,
+    isBooked: boolean,
+    description: string,
+    amenities: string[],
+}
+
+export type T_PropertyCreate = {
+    name: string,
+    banner: string,
+    images: File[],
+    location: string,
+    price: string,
+    description: string,
+    amenities: string[],
+}


### PR DESCRIPTION
This adds the admin property addition UI

1. Checkout to `property-ui-feat`
2. `npm run dev`
3. And login as property owner with the credentials (username: justine, password: 1234)
4. Navigate to properties and you should be able to see the list, create and see properties details

Expected Screenshots Jobs

<img width="1000" alt="Screenshot 2025-03-13 at 8 57 20 PM" src="https://github.com/user-attachments/assets/9abbd760-8492-4b60-a504-571c912a69ee" />
<img width="1000" alt="Screenshot 2025-03-13 at 9 09 52 PM" src="https://github.com/user-attachments/assets/6b860295-d799-45e8-b934-732811823cd4" />
<img width="1000" alt="Screenshot 2025-03-13 at 11 58 52 AM" src="https://github.com/user-attachments/assets/8cedb9ee-b06c-46f3-8528-7a7270d788c7" />
